### PR TITLE
Remove nmcspadden repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "gregneagle"]
 	path = gregneagle
 	url = https://github.com/gregneagle/Profiles
-[submodule "nmcspadden"]
-	path = nmcspadden
-	url = https://github.com/nmcspadden/Profiles
 [submodule "rtrouton"]
 	path = rtrouton
 	url = https://github.com/rtrouton/profiles


### PR DESCRIPTION
Looks like this no longer exists, which caused clayton-bot to fail last January.